### PR TITLE
Download & cache avatar images

### DIFF
--- a/GHFollowers/Custom Views/Cells/FollowerCell.swift
+++ b/GHFollowers/Custom Views/Cells/FollowerCell.swift
@@ -24,6 +24,7 @@ class FollowerCell: UICollectionViewCell {
     
     func set(follower: Follower) {
         usernameLabel.text = follower.login
+        avatarImageView.downloadImage(from: follower.avatarUrl)
     }
     
     private func configure() {

--- a/GHFollowers/Custom Views/GFAvatarImageView.swift
+++ b/GHFollowers/Custom Views/GFAvatarImageView.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class GFAvatarImageView: UIImageView {
     
+    let cache = NetworkManager.shared.cache
     let placeholderImage = UIImage(named: "avatar-placeholder")!
 
     override init(frame: CGRect) {
@@ -26,5 +27,34 @@ class GFAvatarImageView: UIImageView {
         clipsToBounds = true
         image = placeholderImage
         translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    func downloadImage(from urlString: String) {
+        
+        let cacheKey = NSString(string: urlString)
+        if let image = cache.object(forKey: cacheKey) {
+            self.image = image
+            return
+        }
+        
+        // Intentionally not handling errors; use placeholder image if something goes wrong
+        guard let url = URL(string: urlString) else { return }
+        
+        let task = URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
+            guard let self = self else { return }
+            
+            if error != nil { return }
+            guard let response = response as? HTTPURLResponse, response.statusCode == 200 else { return }
+            guard let data = data else { return }
+            guard let image = UIImage(data: data) else { return }
+            
+            self.cache.setObject(image, forKey: cacheKey)
+            
+            DispatchQueue.main.async {
+                self.image = image
+            }
+        }
+        
+        task.resume()
     }
 }

--- a/GHFollowers/Managers/NetworkManager.swift
+++ b/GHFollowers/Managers/NetworkManager.swift
@@ -6,11 +6,12 @@
 //  Copyright © 2020 Brandon Maynard. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 class NetworkManager {
     static let shared = NetworkManager()
-    let baseUrl = "https://api.github.com/users/"
+    private let baseUrl = "https://api.github.com/users/"
+    let cache = NSCache<NSString, UIImage>()
     
     private init() {}
     


### PR DESCRIPTION
- Added downloadImage function to GFAvatarImageView which downloads and caches the avatar image
- Because there is no need to handle errors (placeholder image is displayed if avatar image cannot be downloaded), this downloading image function felt more appropriate in the GFAvatarImageView (doesn’t need all the functionality of the NetworkManager); however, this is certainly a debatable decision