### PR TITLE
Convenience Initializers

### DIFF
--- a/GHFollowers/Custom Views/Buttons/GFButton.swift
+++ b/GHFollowers/Custom Views/Buttons/GFButton.swift
@@ -19,11 +19,10 @@ class GFButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     
-    init(backgroundColor: UIColor, title: String) {
-        super.init(frame: .zero)
+    convenience init(backgroundColor: UIColor, title: String) {
+        self.init(frame: .zero)
         self.backgroundColor = backgroundColor
         self.setTitle(title, for: .normal)
-        configure()
     }
     
     private func configure() {

--- a/GHFollowers/Custom Views/Labels/GFBodyLabel.swift
+++ b/GHFollowers/Custom Views/Labels/GFBodyLabel.swift
@@ -19,10 +19,9 @@ class GFBodyLabel: UILabel {
         fatalError("init(coder:) has not been implemented")
     }
     
-    init(textAlignment: NSTextAlignment) {
-        super.init(frame: .zero)
+    convenience init(textAlignment: NSTextAlignment) {
+        self.init(frame: .zero)
         self.textAlignment = textAlignment
-        configure()
     }
     
     private func configure() {

--- a/GHFollowers/Custom Views/Labels/GFSecondaryTitleLabel.swift
+++ b/GHFollowers/Custom Views/Labels/GFSecondaryTitleLabel.swift
@@ -19,10 +19,9 @@ class GFSecondaryTitleLabel: UILabel {
         fatalError("init(coder:) has not been implemented")
     }
     
-    init(fontSize: CGFloat) {
-        super.init(frame: .zero)
+    convenience init(fontSize: CGFloat) {
+        self.init(frame: .zero)
         font = UIFont.systemFont(ofSize: fontSize, weight: .medium)
-        configure()
     }
     
     private func configure() {

--- a/GHFollowers/Custom Views/Labels/GFTitleLabel.swift
+++ b/GHFollowers/Custom Views/Labels/GFTitleLabel.swift
@@ -19,11 +19,10 @@ class GFTitleLabel: UILabel {
         fatalError("init(coder:) has not been implemented")
     }
     
-    init(textAlignment: NSTextAlignment, fontSize: CGFloat) {
-        super.init(frame: .zero)
+    convenience init(textAlignment: NSTextAlignment, fontSize: CGFloat) {
+        self.init(frame: .zero)
         self.textAlignment = textAlignment
         self.font = UIFont.systemFont(ofSize: fontSize, weight: .bold)
-        configure()
     }
     
     private func configure() {

--- a/GHFollowers/Custom Views/Views/GFEmptyStateView.swift
+++ b/GHFollowers/Custom Views/Views/GFEmptyStateView.swift
@@ -22,10 +22,9 @@ class GFEmptyStateView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    init(message: String) {
-        super.init(frame: .zero)
+    convenience init(message: String) {
+        self.init(frame: .zero)
         messageLabel.text = message
-        configure()
     }
     
     private func configure() {


### PR DESCRIPTION
- For optimization, use convenience initializers so configure() can be called when self.init is called from convenience init