### PR TITLE
Date & Networking Optimizations

### DIFF
--- a/GHFollowers/Custom Views/Cells/FavoriteCell.swift
+++ b/GHFollowers/Custom Views/Cells/FavoriteCell.swift
@@ -23,8 +23,12 @@ class FavoriteCell: UITableViewCell {
     }
     
     func set(favorite: Follower) {
+        avatarImageView.image = nil
         usernameLabel.text = favorite.login
-        avatarImageView.downloadImage(from: favorite.avatarUrl)
+        NetworkManager.shared.downloadImage(from: favorite.avatarUrl) { [weak self] image in
+            guard let self = self else { return }
+            DispatchQueue.main.async { self.avatarImageView.image = image }
+        }
     }
     
     private func configure() {

--- a/GHFollowers/Custom Views/Cells/FollowerCell.swift
+++ b/GHFollowers/Custom Views/Cells/FollowerCell.swift
@@ -23,8 +23,12 @@ class FollowerCell: UICollectionViewCell {
     }
     
     func set(follower: Follower) {
+        avatarImageView.image = nil
         usernameLabel.text = follower.login
-        avatarImageView.downloadImage(from: follower.avatarUrl)
+        NetworkManager.shared.downloadImage(from: follower.avatarUrl) { [weak self] image in
+            guard let self = self else { return }
+            DispatchQueue.main.async { self.avatarImageView.image = image }
+        }
     }
     
     private func configure() {

--- a/GHFollowers/Custom Views/ImageViews/GFAvatarImageView.swift
+++ b/GHFollowers/Custom Views/ImageViews/GFAvatarImageView.swift
@@ -28,33 +28,4 @@ class GFAvatarImageView: UIImageView {
         image = placeholderImage
         translatesAutoresizingMaskIntoConstraints = false
     }
-    
-    func downloadImage(from urlString: String) {
-        
-        let cacheKey = NSString(string: urlString)
-        if let image = cache.object(forKey: cacheKey) {
-            self.image = image
-            return
-        }
-        
-        // Intentionally not handling errors; use placeholder image if something goes wrong
-        guard let url = URL(string: urlString) else { return }
-        
-        let task = URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
-            guard let self = self else { return }
-            
-            if error != nil { return }
-            guard let response = response as? HTTPURLResponse, response.statusCode == 200 else { return }
-            guard let data = data else { return }
-            guard let image = UIImage(data: data) else { return }
-            
-            self.cache.setObject(image, forKey: cacheKey)
-            
-            DispatchQueue.main.async {
-                self.image = image
-            }
-        }
-        
-        task.resume()
-    }
 }

--- a/GHFollowers/Custom Views/ViewControllers/GFUserInfoHeaderVC.swift
+++ b/GHFollowers/Custom Views/ViewControllers/GFUserInfoHeaderVC.swift
@@ -36,7 +36,7 @@ class GFUserInfoHeaderVC: UIViewController {
     }
     
     func configureUIElements() {
-        avatarImageView.downloadImage(from: user.avatarUrl)
+        downloadAvatarImage()
         usernameLabel.text = user.login
         nameLabel.text = user.name ?? ""
         locationLabel.text = user.location ?? "No Location"
@@ -45,6 +45,13 @@ class GFUserInfoHeaderVC: UIViewController {
         
         locationImageView.image = UIImage(systemName: SFSymbols.location)
         locationImageView.tintColor = .secondaryLabel
+    }
+    
+    func downloadAvatarImage() {
+        NetworkManager.shared.downloadImage(from: user.avatarUrl) { [weak self] image in
+            guard let self = self else { return }
+            DispatchQueue.main.async { self.avatarImageView.image = image }
+        }
     }
     
     func addSubviews() {

--- a/GHFollowers/Extensions/String+Ext.swift
+++ b/GHFollowers/Extensions/String+Ext.swift
@@ -26,17 +26,4 @@ extension String {
     func removeWhitespaces() -> String {
         return components(separatedBy: .whitespaces).joined()
     }
-    
-    func convertToDate() -> Date? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.timeZone = .current
-        return dateFormatter.date(from: self)
-    }
-    
-    func convertToDisplayFormat() -> String {
-        guard let date = self.convertToDate() else { return "N/A" }
-        return date.convertToMonthYearFormat()
-    }
 }

--- a/GHFollowers/Managers/NetworkManager.swift
+++ b/GHFollowers/Managers/NetworkManager.swift
@@ -81,11 +81,43 @@ class NetworkManager {
             do {
                 let decoder = JSONDecoder()
                 decoder.keyDecodingStrategy = .convertFromSnakeCase
+                decoder.dateDecodingStrategy = .iso8601
                 let user = try decoder.decode(User.self, from: data)
                 completionHandler(.success(user))
             } catch {
                 completionHandler(.failure(.invalidData))
             }
+        }
+        
+        task.resume()
+    }
+    
+    func downloadImage(from urlString: String, completed: @escaping (UIImage?) -> Void) {
+        
+        let cacheKey = NSString(string: urlString)
+        if let image = cache.object(forKey: cacheKey) {
+            completed(image)
+            return
+        }
+        
+        // Intentionally not handling errors; use placeholder image if something goes wrong
+        guard let url = URL(string: urlString) else {
+            completed(nil)
+            return
+        }
+        
+        let task = URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
+            guard let self = self,
+                error == nil,
+                let response = response as? HTTPURLResponse, response.statusCode == 200,
+                let data = data,
+                let image = UIImage(data: data) else {
+                    completed(nil)
+                    return
+                }
+            
+            self.cache.setObject(image, forKey: cacheKey)
+            completed(image)
         }
         
         task.resume()

--- a/GHFollowers/Model/User.swift
+++ b/GHFollowers/Model/User.swift
@@ -19,5 +19,5 @@ struct User: Codable {
     let htmlUrl: String
     let following: Int
     let followers: Int
-    let createdAt: String
+    let createdAt: Date
 }

--- a/GHFollowers/Screens/UserInfoVC.swift
+++ b/GHFollowers/Screens/UserInfoVC.swift
@@ -63,7 +63,7 @@ class UserInfoVC: UIViewController {
         self.add(childVC: repoItemVC, to: self.itemViewOne)
         self.add(childVC: followerItemVC, to: self.itemViewTwo)
         self.add(childVC: GFUserInfoHeaderVC(user: user), to: self.headerView)
-        self.dateLabel.text = "Github since \(user.createdAt.convertToDisplayFormat())"
+        self.dateLabel.text = "Github since \(user.createdAt.convertToMonthYearFormat())"
     }
     
     func layoutUI() {


### PR DESCRIPTION
- Updated createdBy to be a Date and using date decoding strategy .iso8601 so we can accept the date and only need to do one conversion to String for display
- Moved download avatar image network call to Network Manager
- In cell set functions, set the avatar image to nil prior to downloading the avatar image; this resolves issue where cell was resused and initially showed another user’s avatar image