### PR TITLE
Enum Optimizations

### DIFF
--- a/GHFollowers/Custom Views/ImageViews/GFAvatarImageView.swift
+++ b/GHFollowers/Custom Views/ImageViews/GFAvatarImageView.swift
@@ -11,7 +11,7 @@ import UIKit
 class GFAvatarImageView: UIImageView {
     
     let cache = NetworkManager.shared.cache
-    let placeholderImage = UIImage(named: "avatar-placeholder")!
+    let placeholderImage = Images.placeholder
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/GHFollowers/Custom Views/ViewControllers/GFUserInfoHeaderVC.swift
+++ b/GHFollowers/Custom Views/ViewControllers/GFUserInfoHeaderVC.swift
@@ -43,7 +43,7 @@ class GFUserInfoHeaderVC: UIViewController {
         bioLabel.text = user.bio ?? "No bio available"
         bioLabel.numberOfLines = 3
         
-        locationImageView.image = UIImage(systemName: SFSymbols.location)
+        locationImageView.image = SFSymbols.location
         locationImageView.tintColor = .secondaryLabel
     }
     

--- a/GHFollowers/Custom Views/Views/GFEmptyStateView.swift
+++ b/GHFollowers/Custom Views/Views/GFEmptyStateView.swift
@@ -36,7 +36,7 @@ class GFEmptyStateView: UIView {
         messageLabel.numberOfLines = 3
         messageLabel.textColor = .secondaryLabel
         
-        logoImageView.image = UIImage(named: "empty-state-logo")
+        logoImageView.image = Images.emptyStateLogo
         logoImageView.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([

--- a/GHFollowers/Custom Views/Views/GFItemInfoView.swift
+++ b/GHFollowers/Custom Views/Views/GFItemInfoView.swift
@@ -57,16 +57,16 @@ class GFItemInfoView: UIView {
     func set(itemInfoType: itemInfoType, withCount count: Int) {
         switch itemInfoType {
         case .repos:
-            symbolImageView.image = UIImage(systemName: SFSymbols.repos)
+            symbolImageView.image = SFSymbols.repos
             titleLabel.text = "Public Repos"
         case .gists:
-            symbolImageView.image = UIImage(systemName: SFSymbols.gists)
+            symbolImageView.image = SFSymbols.gists
             titleLabel.text = "Public Gists"
         case .followers:
-            symbolImageView.image = UIImage(systemName: SFSymbols.followers)
+            symbolImageView.image = SFSymbols.followers
             titleLabel.text = "Followers"
         case .following:
-            symbolImageView.image = UIImage(systemName: SFSymbols.following)
+            symbolImageView.image = SFSymbols.following
             titleLabel.text = "Following"
         }
         

--- a/GHFollowers/Utilties/Constants.swift
+++ b/GHFollowers/Utilties/Constants.swift
@@ -9,15 +9,17 @@
 import UIKit
 
 enum SFSymbols {
-    static let location = "mappin.and.ellipse"
-    static let repos = "folder"
-    static let gists = "text.alignleft"
-    static let followers = "heart"
-    static let following = "person.2"
+    static let location = UIImage(systemName: "mappin.and.ellipse")
+    static let repos = UIImage(systemName: "folder")
+    static let gists = UIImage(systemName: "text.alignleft")
+    static let followers = UIImage(systemName: "heart")
+    static let following = UIImage(systemName: "person.2")
 }
 
 enum Images {
+    static let emptyStateLogo = UIImage(named: "empty-state-logo")
     static let ghLogo = UIImage(named: "gh-logo")
+    static let placeholder = UIImage(named: "avatar-placeholder")
 }
 
 

--- a/GHFollowers/Utilties/UIHelper.swift
+++ b/GHFollowers/Utilties/UIHelper.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-struct UIHelper {
+enum UIHelper {
     
     static func createThreeColumnFlowLayout(in view: UIView) -> UICollectionViewFlowLayout {
         let width = view.bounds.width


### PR DESCRIPTION
- Moved UIImage(named:) to constants file Images enum
- SFSymbols enum uses UIImage(systemName:) so we don’t have to do that elsewhere in code (aligns with Images enum)
- UIHelper is now an enum so it cannot be instantiated (only contains a static function)