### PR TITLE
Scrolling & Pagination Bug Fixes

### DIFF
--- a/GHFollowers/Screens/FollowerListVC.swift
+++ b/GHFollowers/Screens/FollowerListVC.swift
@@ -24,6 +24,7 @@ class FollowerListVC: GFDataLoadingVC {
     var page = 1
     var hasMoreFollowers = true
     var isSearching = false
+    var isLoadingMoreFollowers = false
     
     var collectionView: UICollectionView!
     var dataSource: UICollectionViewDiffableDataSource<Section, Follower>!
@@ -79,6 +80,7 @@ class FollowerListVC: GFDataLoadingVC {
     
     func getFollowers(username: String, page: Int) {
         showLoadingView()
+        isLoadingMoreFollowers = true
         NetworkManager.shared.getFollowers(for: username, page: page) { [weak self] result in
             guard let self = self else { return }
             self.dismissLoadingView()
@@ -102,6 +104,8 @@ class FollowerListVC: GFDataLoadingVC {
                     self.navigationController?.popViewController(animated: true)
                 }
             }
+            
+            self.isLoadingMoreFollowers = false
         }
     }
     
@@ -157,7 +161,7 @@ extension FollowerListVC: UICollectionViewDelegate {
         let height = scrollView.frame.size.height
         
         if offsetY > contentHeight - height {
-            guard hasMoreFollowers else { return }
+            guard hasMoreFollowers, !isLoadingMoreFollowers else { return }
             page += 1
             getFollowers(username: username, page: page)
         }
@@ -199,16 +203,7 @@ extension FollowerListVC: FollowerListVCDelegate {
         page = 1
         followers.removeAll()
         filteredFollowers.removeAll()
-        
-        collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
-        
-        if isSearching {
-            navigationItem.searchController?.searchBar.text = ""
-            navigationItem.searchController?.isActive = false
-            navigationItem.searchController?.dismiss(animated: false)
-            isSearching = false
-        }
-        
+        collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: true)
         getFollowers(username: username, page: page)
     }
 }


### PR DESCRIPTION
- Resolved issue where, after tapping Get Followers, the follower list would not scroll to top
- Resolved issue where user could continue scrolling and making more calls to get more followers on another page before the first network call had returned