### PR TITLE
Refactoring Network Calls to Async/Await

### DIFF
--- a/GHFollowers/Custom Views/ImageViews/GFAvatarImageView.swift
+++ b/GHFollowers/Custom Views/ImageViews/GFAvatarImageView.swift
@@ -30,9 +30,6 @@ class GFAvatarImageView: UIImageView {
     }
     
     func downloadImage(fromURL url: String) {
-        NetworkManager.shared.downloadImage(from: url) { [weak self] image in
-            guard let self = self else { return }
-            DispatchQueue.main.async { self.image = image }
-        }
+        Task { image = await NetworkManager.shared.downloadImage(from: url) ?? placeholderImage }
     }
 }

--- a/GHFollowers/Extensions/UIViewController+Ext.swift
+++ b/GHFollowers/Extensions/UIViewController+Ext.swift
@@ -11,13 +11,20 @@ import SafariServices
 
 extension UIViewController {
     
-    func presentGFAlertOnMainThread(title: String, message: String, buttonTitle: String, dismissAction: (() -> Void)? = nil) {
-        DispatchQueue.main.async {
-            let alertVC = GFAlertVC(title: title, message: message, buttonTitle: buttonTitle, dismissAction: dismissAction)
-            alertVC.modalPresentationStyle = .overFullScreen
-            alertVC.modalTransitionStyle = .crossDissolve
-            self.present(alertVC, animated: true)
-        }
+    func presentGFAlert(title: String, message: String, buttonTitle: String, dismissAction: (() -> Void)? = nil) {
+        let alertVC = GFAlertVC(title: title, message: message, buttonTitle: buttonTitle, dismissAction: dismissAction)
+        alertVC.modalPresentationStyle = .overFullScreen
+        alertVC.modalTransitionStyle = .crossDissolve
+        self.present(alertVC, animated: true)
+    }
+    
+    func presentDefaultError() {
+        let alertVC = GFAlertVC(title: "Something Went Wrong",
+                                message: "We were unable to complete your task at this time. Please try again.",
+                                buttonTitle: "Ok")
+        alertVC.modalPresentationStyle = .overFullScreen
+        alertVC.modalTransitionStyle = .crossDissolve
+        self.present(alertVC, animated: true)
     }
     
     func presentSafariVC(with url: URL) {

--- a/GHFollowers/Managers/NetworkManager.swift
+++ b/GHFollowers/Managers/NetworkManager.swift
@@ -72,76 +72,40 @@ class NetworkManager {
         }
         
         do {
-            return try self.decoder.decode([Follower].self, from: data)
+            return try decoder.decode([Follower].self, from: data)
         } catch {
             throw GFError.invalidData
         }
     }
     
-    func getUserInfo(for username: String, completionHandler: @escaping (Result<User, GFError>) -> Void) {
+    func getUserInfo(for username: String) async throws -> User {
         let endpoint = baseUrl + "\(username)"
+        guard let url = URL(string: endpoint) else { throw GFError.invalidUsername }
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let response = response as? HTTPURLResponse, response.statusCode == 200 else { throw GFError.invalidResponse }
         
-        guard let url = URL(string: endpoint) else {
-            completionHandler(.failure(.invalidUsername))
-            return
+        do {
+            return try decoder.decode(User.self, from: data)
+        } catch {
+            throw GFError.invalidData
         }
-        
-        let task = URLSession.shared.dataTask(with: url) { (data, response, error) in
-            
-            if let _ = error {
-                completionHandler(.failure(.unableToComplete))
-                return
-            }
-            
-            guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {
-                completionHandler(.failure(.invalidResponse))
-                return
-            }
-            
-            guard let data = data else {
-                completionHandler(.failure(.invalidData))
-                return
-            }
-            
-            do {
-                let user = try self.decoder.decode(User.self, from: data)
-                completionHandler(.success(user))
-            } catch {
-                completionHandler(.failure(.invalidData))
-            }
-        }
-        
-        task.resume()
     }
     
-    func downloadImage(from urlString: String, completed: @escaping (UIImage?) -> Void) {
+    func downloadImage(from urlString: String) async -> UIImage? {
         let cacheKey = NSString(string: urlString)
-        
-        if let image = cache.object(forKey: cacheKey) {
-            completed(image)
-            return
-        }
+        if let image = cache.object(forKey: cacheKey) { return image }
         
         // Intentionally not handling errors; use placeholder image if something goes wrong
-        guard let url = URL(string: urlString) else {
-            completed(nil)
-            return
-        }
+        guard let url = URL(string: urlString) else { return nil }
         
-        let task = URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
-            guard let self = self,
-                error == nil,
-                let response = response as? HTTPURLResponse, response.statusCode == 200,
-                let data = data,
-                let image = UIImage(data: data) else {
-                    completed(nil)
-                    return
-                }
-            
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard let image = UIImage(data: data) else { return nil }
             self.cache.setObject(image, forKey: cacheKey)
-            completed(image)
+            return image
+        } catch {
+            return nil
         }
         
-        task.resume()
     }
 }

--- a/GHFollowers/Screens/FavoritesListVC.swift
+++ b/GHFollowers/Screens/FavoritesListVC.swift
@@ -51,7 +51,7 @@ class FavoritesListVC: GFDataLoadingVC {
                 self.updateUI(with: favorites)
                 
             case .failure(let error):
-                self.presentGFAlertOnMainThread(title: "Something went wrong", message: error.rawValue, buttonTitle: "Ok")
+                self.presentGFAlert(title: "Something went wrong", message: error.rawValue, buttonTitle: "Ok")
             }
         }
     }
@@ -99,7 +99,7 @@ extension FavoritesListVC: UITableViewDataSource, UITableViewDelegate {
                 tableView.deleteRows(at: [indexPath], with: .left)
                 return
             }
-            self.presentGFAlertOnMainThread(title: "Unable to remove", message: error.rawValue, buttonTitle: "Ok")
+            self.presentGFAlert(title: "Unable to remove", message: error.rawValue, buttonTitle: "Ok")
         }
     }
 }

--- a/GHFollowers/Screens/FavoritesListVC.swift
+++ b/GHFollowers/Screens/FavoritesListVC.swift
@@ -51,7 +51,9 @@ class FavoritesListVC: GFDataLoadingVC {
                 self.updateUI(with: favorites)
                 
             case .failure(let error):
-                self.presentGFAlert(title: "Something went wrong", message: error.rawValue, buttonTitle: "Ok")
+                DispatchQueue.main.async {
+                    self.presentGFAlert(title: "Something went wrong", message: error.rawValue, buttonTitle: "Ok")
+                }
             }
         }
     }
@@ -99,7 +101,10 @@ extension FavoritesListVC: UITableViewDataSource, UITableViewDelegate {
                 tableView.deleteRows(at: [indexPath], with: .left)
                 return
             }
-            self.presentGFAlert(title: "Unable to remove", message: error.rawValue, buttonTitle: "Ok")
+            
+            DispatchQueue.main.async {
+                self.presentGFAlert(title: "Unable to remove", message: error.rawValue, buttonTitle: "Ok")
+            }
         }
     }
 }

--- a/GHFollowers/Screens/SearchVC.swift
+++ b/GHFollowers/Screens/SearchVC.swift
@@ -40,7 +40,7 @@ class SearchVC: UIViewController {
     
     @objc func pushFollowerListVC() {
         guard isUsernameEntered else {
-            presentGFAlertOnMainThread(title: "Empty Username", message: "Please enter a username.  We need to know who to look for 😀.", buttonTitle: "Ok")
+            presentGFAlert(title: "Empty Username", message: "Please enter a username.  We need to know who to look for 😀.", buttonTitle: "Ok")
             return
         }
         

--- a/GHFollowers/Screens/UserInfoVC.swift
+++ b/GHFollowers/Screens/UserInfoVC.swift
@@ -61,7 +61,7 @@ class UserInfoVC: GFDataLoadingVC {
                 DispatchQueue.main.async { self.configureUIElements(with: user) }
                 
             case .failure(let error):
-                self.presentGFAlertOnMainThread(title: "Something went wrong", message: error.rawValue, buttonTitle: "Ok") {
+                self.presentGFAlert(title: "Something went wrong", message: error.rawValue, buttonTitle: "Ok") {
                     self.dismiss(animated: true)
                 }
             }
@@ -121,7 +121,7 @@ class UserInfoVC: GFDataLoadingVC {
 extension UserInfoVC: GFRepoItemVCDelegate {
     func didTapGitHubProfile(for user: User) {
         guard let url = URL(string: user.htmlUrl) else {
-            presentGFAlertOnMainThread(title: "Invalid URL", message: "The url attached to this user is invalid.", buttonTitle: "Ok")
+            presentGFAlert(title: "Invalid URL", message: "The url attached to this user is invalid.", buttonTitle: "Ok")
             return
         }
         
@@ -132,7 +132,7 @@ extension UserInfoVC: GFRepoItemVCDelegate {
 extension UserInfoVC: GFFollowerItemVCDelegate {
     func didTapGetFollowers(for user: User) {
         guard user.followers != 0 else {
-            presentGFAlertOnMainThread(title: "No followers", message: "This user has no followers. What a shame 😔.", buttonTitle: "So sad")
+            presentGFAlert(title: "No followers", message: "This user has no followers. What a shame 😔.", buttonTitle: "So sad")
             return
         }
         

--- a/GHFollowers/Screens/UserInfoVC.swift
+++ b/GHFollowers/Screens/UserInfoVC.swift
@@ -53,16 +53,17 @@ class UserInfoVC: GFDataLoadingVC {
     }
     
     func getUserInfo() {
-        NetworkManager.shared.getUserInfo(for: username) { [weak self] result in
-            guard let self = self else { return }
-            
-            switch result {
-            case .success(let user):
-                DispatchQueue.main.async { self.configureUIElements(with: user) }
-                
-            case .failure(let error):
-                self.presentGFAlert(title: "Something went wrong", message: error.rawValue, buttonTitle: "Ok") {
-                    self.dismiss(animated: true)
+        Task {
+            do {
+                let user = try await NetworkManager.shared.getUserInfo(for: username)
+                configureUIElements(with: user)
+            } catch {
+                if let gfError = error as? GFError {
+                    presentGFAlert(title: "Something went wrong", message: gfError.rawValue, buttonTitle: "Ok") {
+                        self.dismiss(animated: true)
+                    }
+                } else {
+                    presentDefaultError()
                 }
             }
         }


### PR DESCRIPTION
Refactoring Network Calls to Async/Await - Part 1
- Updated getFollowers function to use async/await
- Moved decoder to a NetworkManager property
- Updated presentGFAlertOnMainThread without main thread because UIViewController is now a main actor (therefore everything is guaranteed to be done on main thread)
- Left commented out code for educational purposes to easily view differences between previous network call and the async/await

Refactoring Network Calls to Async/Await - Part 2
- Updated getUserInfo & downloadImage NetworkManager functions using async/await
- Added main thread back for specific GFError alerts